### PR TITLE
The qemu parameters fixed, usbexport now shows the progress and dd was replaced with cat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ FILES = boot loader
 
 all: folders $(FILES)
 	rm -rf ./bin/boot.bin
-	dd if=./bin/stage1.bin >> ./bin/boot.bin
-	dd if=./bin/stage2.bin >> ./bin/boot.bin
+	cat bin/stage1.bin > bin/boot.bin
+	cat bin/stage2.bin >> bin/boot.bin
 
 folders:
 	mkdir -p ./bin/

--- a/boot.sh
+++ b/boot.sh
@@ -5,12 +5,12 @@ case $1 in
 		echo ""
 		echo "Booting FLOPPY"
 		echo ""
-		qemu-system-i386 -fda ./bin/boot.bin
+		qemu-system-i386 -drive file=./bin/boot.bin,format=raw,if=floppy
 	;;
 	*)
 		echo ""
 		echo "Booting HDD"
 		echo ""
-		qemu-system-i386 -hda ./bin/boot.bin
+		qemu-system-i386 -drive file=./bin/boot.bin,format=raw
 	;;
 esac

--- a/loadToUsb.sh
+++ b/loadToUsb.sh
@@ -1,2 +1,2 @@
 #/bin/bash
-sudo dd if=./bin/boot.bin of=/dev/sdb
+sudo dd if=./bin/boot.bin of=/dev/sdb status=progress

--- a/src/boot.asm
+++ b/src/boot.asm
@@ -136,9 +136,9 @@ secPerTrack: db 63
 
 readLoopCount db 10
 
-welcomeMessage: db 'BIOS Bootloader test',0xa,0xd, 0
-driveReadError: db 'There was an error reading from disk', 0xa, 0xd, 0
-errorNumber: db 'Error No:', 0, 0xa, 0xd, 0
+welcomeMessage: db 'BIOS Bootloader test',10, 13, 0
+driveReadError: db 'There was an error reading from disk', 10, 13, 0
+errorNumber: db 'Error No:', 0, 10, 13, 0
 
 times 510- ($-$$) db 0
 dw 0xAA55

--- a/src/stage2.asm
+++ b/src/stage2.asm
@@ -1,10 +1,10 @@
 [bits 16]
 [org 0x7E00]
-
+stage2_begin:
 	xor ax, ax
 	xor bx, bx
 
-	mov ah, 0xE
+	mov ah, 0x0E
 	mov al, 'H'
 	int 0x10
 


### PR DESCRIPTION
dd does not output to the stdout, you must use cat for export.
You should also indicate that the floppy/hard drive is in raw mode so it does not show the warning, as well as it allows you to write to any of the drives